### PR TITLE
router-linkで書かずにaで書き直した

### DIFF
--- a/src/components/List.vue
+++ b/src/components/List.vue
@@ -4,7 +4,7 @@
       <div v-if="post._embedded['wp:featuredmedia']">
         <img :src="post._embedded['wp:featuredmedia'][0].source_url" alt="" class="thumbnail">
       </div>
-      <router-link :to="`/article/${ post.id }`">{{ post.title.rendered }}</router-link>
+      <a :href="`/article/${ post.id }`">{{ post.title.rendered }}</a>
       <time>{{ post.date }}</time>
     </div>
   </div>


### PR DESCRIPTION
## 目的
router-link でリンクを描画すると、リンクを押した先が再描画されずにページの途中が表示されてしまうのを直したい。

## やったこと
router-link で描画せずにaタグでリンクを描画するようにした。